### PR TITLE
Remove Twitter link

### DIFF
--- a/source/index.haml
+++ b/source/index.haml
@@ -55,8 +55,6 @@
         %a(href='https://github.com/jonallured/shrt') source
         |
         %a(href='https://www.jonallured.com') jonallured.com
-        |
-        %a(href='https://twitter.com/jonallured') @jonallured
 
     %article
       %h2 general


### PR DESCRIPTION
I'm not really wanting to highlight my Twitter account anymore so I'll just remove it altogether.